### PR TITLE
Update svg-to-jsx dependency to 0.0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
   "dependencies": {
     "loader-utils": "^0.2.11",
     "object-assign": "^4.0.1",
-    "svg-to-jsx": "0.0.4"
+    "svg-to-jsx": "0.0.13"
   }
 }


### PR DESCRIPTION
Changelog:
- Added support for passign props to JSX
- Add support for React 0.14 namespaced SVG tags
